### PR TITLE
add map display feature for shops

### DIFF
--- a/app/components/AllShopsMap.tsx
+++ b/app/components/AllShopsMap.tsx
@@ -1,0 +1,99 @@
+// app/components/AllShopsMap.tsx
+import type { Shop } from '../types/microcms'
+
+type Props = {
+  shops: Shop[]
+}
+
+export const AllShopsMap = ({ shops }: Props) => {
+  // 座標を持つ店舗のみフィルタリング
+  const shopsWithCoords = shops.filter(shop => shop.latitude && shop.longitude)
+  
+  if (shopsWithCoords.length === 0) {
+    return (
+      <div class="bg-gray-100 rounded-lg p-8 text-center">
+        <p class="text-gray-600">座標が登録されている店舗がありません</p>
+      </div>
+    )
+  }
+
+  // 全店舗の中心点を計算
+  const avgLat = shopsWithCoords.reduce((sum, shop) => sum + (shop.latitude || 0), 0) / shopsWithCoords.length
+  const avgLng = shopsWithCoords.reduce((sum, shop) => sum + (shop.longitude || 0), 0) / shopsWithCoords.length
+
+  // 全店舗が収まる範囲を計算
+  const lats = shopsWithCoords.map(shop => shop.latitude || 0)
+  const lngs = shopsWithCoords.map(shop => shop.longitude || 0)
+  const minLat = Math.min(...lats)
+  const maxLat = Math.max(...lats)
+  const minLng = Math.min(...lngs)
+  const maxLng = Math.max(...lngs)
+
+  // bbox を少し広めに設定
+  const padding = 0.01
+  const bbox = `${minLng - padding},${minLat - padding},${maxLng + padding},${maxLat + padding}`
+
+  // OpenStreetMap の embed URL を構築
+  // 複数マーカーを表示するために、各店舗のマーカーをクエリパラメータに追加
+  const markers = shopsWithCoords
+    .map(shop => `pin-s+ff0000(${shop.longitude},${shop.latitude})`)
+    .join(',')
+
+  // Leaflet を使った独自マップ実装
+  return (
+    <div class="space-y-4">
+      <div class="w-full rounded-lg overflow-hidden shadow-md" style="height: 600px;">
+        <div id="map" class="w-full h-full" data-shops={JSON.stringify(shopsWithCoords)} />
+      </div>
+      
+      <div class="text-right text-sm text-gray-600">
+        <p>{shopsWithCoords.length} 店舗を表示中</p>
+      </div>
+      
+      <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+      <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+      <script dangerouslySetInnerHTML={{
+        __html: `
+          (function() {
+            const mapEl = document.getElementById('map');
+            const shops = JSON.parse(mapEl.dataset.shops);
+            
+            // 地図の初期化
+            const map = L.map('map').setView([${avgLat}, ${avgLng}], 10);
+            
+            // OpenStreetMap タイルレイヤーを追加
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+              attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            }).addTo(map);
+            
+            // 各店舗にマーカーを追加
+            shops.forEach(shop => {
+              const marker = L.marker([shop.latitude, shop.longitude]).addTo(map);
+              marker.bindPopup(\`
+                <div style="min-width: 200px;">
+                  <h3 style="font-weight: bold; margin-bottom: 8px;">
+                    <a href="/shops/\${shop.id}" style="color: #2563eb; text-decoration: none;">
+                      \${shop.name}
+                    </a>
+                  </h3>
+                  <p style="font-size: 12px; color: #666;">
+                    \${shop.area.name} - \${shop.genre.name}
+                  </p>
+                  <p style="font-size: 12px; margin-top: 4px;">
+                    \${shop.address}
+                  </p>
+                </div>
+              \`);
+            });
+            
+            // 全マーカーが収まるように調整
+            if (shops.length > 0) {
+              const bounds = L.latLngBounds(shops.map(shop => [shop.latitude, shop.longitude]));
+              map.fitBounds(bounds, { padding: [50, 50] });
+            }
+          })();
+        `
+      }} />
+    </div>
+  )
+}

--- a/app/libs/microcms.ts
+++ b/app/libs/microcms.ts
@@ -50,6 +50,13 @@ export const getShops = async ({ client, queries }: ClientWithQueries) => {
   })
 }
 
+export const getAllShops = async ({ client, queries }: ClientWithQueries) => {
+  return await client.getAllContents<Shop>({
+    endpoint: 'shop',
+    queries,
+  })
+}
+
 // 店舗詳細取得
 export const getShopDetail = async ({ client, contentId, queries }: ClientWithContentId) => {
   return await client.getListDetail<Shop>({

--- a/app/routes/shops/index.tsx
+++ b/app/routes/shops/index.tsx
@@ -24,7 +24,15 @@ export default createRoute(async (c) => {
 
   return c.render(
     <Container>
-      <h1 class="text-3xl font-bold mb-6">お店一覧</h1>
+      <div class="flex justify-between items-center mb-6">
+        <h1 class="text-3xl font-bold">お店一覧</h1>
+        <a
+          href="/shops/map"
+          class="inline-block px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          地図で見る
+        </a>
+      </div>
 
       {shops.length === 0 ? (
         <p class="text-gray-500">お店が登録されていません</p>

--- a/app/routes/shops/map.tsx
+++ b/app/routes/shops/map.tsx
@@ -1,0 +1,89 @@
+// app/routes/shops/map.tsx
+import { createRoute } from 'honox/factory'
+import { getMicroCMSClient, getAllShops } from '../../libs/microcms'
+import { Container } from '../../components/Container'
+import { AllShopsMap } from '../../components/AllShopsMap'
+import type { Meta } from '../../types/meta'
+
+export default createRoute(async (c) => {
+  const client = getMicroCMSClient({
+    serviceDomain: c.env.SERVICE_DOMAIN,
+    apiKey: c.env.API_KEY,
+  })
+
+  // 全店舗を取得（座標フィールドも含める）
+  const shops = await getAllShops({
+    client,
+    queries: {
+      fields: 'id,name,address,latitude,longitude,area,genre',
+      limit: 1000, // 全店舗取得
+    },
+  })
+
+  const url = new URL(c.req.url)
+  const canonicalUrl = `${url.protocol}//${url.host}/shops/map`
+
+  const meta: Meta = {
+    title: `店舗マップ - 飯ログ`,
+    description: '訪問した全店舗を地図上で確認できます',
+    keywords: '店舗マップ,飯ログ,地図',
+    canonicalUrl: canonicalUrl,
+    ogpType: 'website' as const,
+    ogpUrl: canonicalUrl,
+  }
+
+  return c.render(
+    <Container>
+      <div class="space-y-6">
+        <div class="flex items-center justify-between">
+          <h1 class="text-3xl font-bold">店舗マップ</h1>
+          <a href="/shops" class="text-blue-600 hover:text-blue-800 hover:underline">
+            リスト表示に戻る →
+          </a>
+        </div>
+
+        <AllShopsMap shops={shops} />
+
+        {/* エリア別・ジャンル別の統計情報 */}
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
+          <div class="bg-white rounded-lg shadow p-6">
+            <h2 class="text-xl font-bold mb-4">エリア別店舗数</h2>
+            <div class="space-y-2">
+              {Array.from(new Set(shops.map((s) => s.area.name)))
+                .map((area) => ({
+                  name: area,
+                  count: shops.filter((s) => s.area.name === area).length,
+                }))
+                .sort((a, b) => b.count - a.count)
+                .map(({ name, count }) => (
+                  <div class="flex justify-between items-center">
+                    <span>{name}</span>
+                    <span class="font-semibold">{count}店舗</span>
+                  </div>
+                ))}
+            </div>
+          </div>
+
+          <div class="bg-white rounded-lg shadow p-6">
+            <h2 class="text-xl font-bold mb-4">ジャンル別店舗数</h2>
+            <div class="space-y-2">
+              {Array.from(new Set(shops.map((s) => s.genre.name)))
+                .map((genre) => ({
+                  name: genre,
+                  count: shops.filter((s) => s.genre.name === genre).length,
+                }))
+                .sort((a, b) => b.count - a.count)
+                .map(({ name, count }) => (
+                  <div class="flex justify-between items-center">
+                    <span>{name}</span>
+                    <span class="font-semibold">{count}店舗</span>
+                  </div>
+                ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Container>,
+    { meta }
+  )
+})

--- a/app/types/microcms.ts
+++ b/app/types/microcms.ts
@@ -20,6 +20,8 @@ export interface Genre extends MicroCMSContentId, MicroCMSDate {
 export interface Shop extends MicroCMSContentId, MicroCMSDate {
   name: string
   address: string
+  latitude: number
+  longitude: number
   area: Area
   genre: Genre
   memo: string // textArea (required)


### PR DESCRIPTION
Closes #2

- Add AllShopsMap component with Leaflet integration
- Add /shops/map route to display all shops on map
- Add getAllShops function to fetch all shop data
- Update Shop type with latitude and longitude fields
- Add map link to shops index page

🤖 Generated with [Claude Code](https://claude.com/claude-code)