### PR TITLE
feat: 人気記事ページとページビュー計測を追加

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -20,6 +20,11 @@ export const Footer = () => {
                 </a>
               </li>
               <li>
+                <a href="/popular" class="text-gray-300 hover:text-white transition-colors">
+                  人気記事
+                </a>
+              </li>
+              <li>
                 <a href="/about" class="text-gray-300 hover:text-white transition-colors">
                   About
                 </a>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -21,6 +21,11 @@ export function Header() {
                 </a>
               </li>
               <li>
+                <a href="/popular" class="text-gray-600 hover:text-gray-900">
+                  人気記事
+                </a>
+              </li>
+              <li>
                 <a href="/about" class="text-gray-600 hover:text-gray-900">
                   About
                 </a>

--- a/app/components/PopularArticleCard.tsx
+++ b/app/components/PopularArticleCard.tsx
@@ -1,0 +1,33 @@
+import type { PopularPage } from '../libs/pageview'
+
+type Props = {
+  article: PopularPage
+  rank: number
+}
+
+export const PopularArticleCard = ({ article, rank }: Props) => {
+  return (
+    <article class="bg-white rounded-lg shadow-lg p-4 md:p-6 hover:shadow-xl transition-shadow">
+      <a href={article.page_path} class="flex flex-col md:flex-row gap-4 md:gap-6">
+        <div class="flex-shrink-0 flex items-center justify-center w-10 h-10 md:w-12 md:h-12 bg-gray-800 text-white font-bold rounded-full text-lg">
+          {rank}
+        </div>
+        {article.thumbnail_url && (
+          <div class="flex-shrink-0 w-full md:w-48">
+            <img
+              src={article.thumbnail_url}
+              alt={article.title}
+              class="w-full aspect-[4/3] object-cover rounded-lg"
+            />
+          </div>
+        )}
+        <div class="flex-1 min-w-0">
+          <h2 class="text-lg md:text-xl font-bold mb-2 hover:text-blue-600">
+            {article.title} - {article.shop_name}
+          </h2>
+          <p class="text-sm text-gray-500">{article.total_count} views</p>
+        </div>
+      </a>
+    </article>
+  )
+}

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -11,6 +11,7 @@ declare module 'hono' {
     Bindings: {
       SERVICE_DOMAIN: string
       API_KEY: string
+      DB: D1Database
     }
   }
   interface ContextRenderer {

--- a/app/libs/pageview.ts
+++ b/app/libs/pageview.ts
@@ -1,0 +1,53 @@
+import type { Visit } from '../types/microcms'
+
+type PageViewParams = {
+  db: D1Database
+  pagePath: string
+  contentId: string
+  pageType: string
+  visit: Visit
+}
+
+export const recordPageView = async ({
+  db,
+  pagePath,
+  contentId,
+  pageType,
+  visit,
+}: PageViewParams) => {
+  const today = new Date().toISOString().split('T')[0]
+  const now = new Date().toISOString()
+
+  await db.batch([
+    // daily_pages: 日別カウントをupsert
+    db
+      .prepare(
+        `INSERT INTO daily_pages (page_path, content_id, page_type, date, count)
+         VALUES (?, ?, ?, ?, 1)
+         ON CONFLICT(page_path, date) DO UPDATE SET count = count + 1`
+      )
+      .bind(pagePath, contentId, pageType, today),
+
+    // popular_pages: 累計カウントをupsert + メタ情報更新
+    db
+      .prepare(
+        `INSERT INTO popular_pages (page_path, content_id, page_type, title, thumbnail_url, shop_name, total_count, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+         ON CONFLICT(page_path) DO UPDATE SET
+           total_count = total_count + 1,
+           title = excluded.title,
+           thumbnail_url = excluded.thumbnail_url,
+           shop_name = excluded.shop_name,
+           updated_at = excluded.updated_at`
+      )
+      .bind(
+        pagePath,
+        contentId,
+        pageType,
+        visit.title,
+        visit.thumbnail?.url ?? '',
+        visit.shop?.name ?? '',
+        now
+      ),
+  ])
+}

--- a/app/libs/pageview.ts
+++ b/app/libs/pageview.ts
@@ -1,11 +1,35 @@
 import type { Visit } from '../types/microcms'
 
+export type PopularPage = {
+  page_path: string
+  content_id: string
+  page_type: string
+  title: string
+  thumbnail_url: string
+  shop_name: string
+  total_count: number
+}
+
 type PageViewParams = {
   db: D1Database
   pagePath: string
   contentId: string
   pageType: string
   visit: Visit
+}
+
+export const getPopularPages = async (db: D1Database, limit = 10): Promise<PopularPage[]> => {
+  const result = await db
+    .prepare(
+      `SELECT page_path, content_id, page_type, title, thumbnail_url, shop_name, total_count
+       FROM popular_pages
+       WHERE page_type = 'visit'
+       ORDER BY total_count DESC
+       LIMIT ?`
+    )
+    .bind(limit)
+    .all<PopularPage>()
+  return result.results
 }
 
 export const recordPageView = async ({

--- a/app/routes/popular.tsx
+++ b/app/routes/popular.tsx
@@ -1,0 +1,42 @@
+import { createRoute } from 'honox/factory'
+import { getPopularPages } from '../libs/pageview'
+import { Container } from '../components/Container'
+import { PopularArticleCard } from '../components/PopularArticleCard'
+import { PageHeading } from '../components/PageHeading'
+import { LinkToTop } from '../components/LinkToTop'
+import type { Meta } from '../types/meta'
+
+export default createRoute(async (c) => {
+  const url = new URL(c.req.url)
+  const canonicalUrl = `${url.protocol}//${url.host}/popular`
+
+  const meta: Meta = {
+    title: '人気記事 - 飯ログ',
+    description: 'よく読まれている訪問記録のランキング',
+    keywords: '人気記事,ランキング',
+    canonicalUrl: canonicalUrl,
+    ogpType: 'website' as const,
+    ogpUrl: canonicalUrl,
+  }
+
+  const popularPages = await getPopularPages(c.env.DB, 20)
+
+  return c.render(
+    <Container>
+      <div class="space-y-6">
+        <PageHeading>人気記事</PageHeading>
+        {popularPages.length === 0 ? (
+          <p class="text-gray-500">まだデータがありません</p>
+        ) : (
+          <div class="space-y-6">
+            {popularPages.map((article, index) => (
+              <PopularArticleCard article={article} rank={index + 1} />
+            ))}
+          </div>
+        )}
+      </div>
+      <LinkToTop />
+    </Container>,
+    { meta }
+  )
+})

--- a/app/routes/visits/[id].tsx
+++ b/app/routes/visits/[id].tsx
@@ -5,6 +5,7 @@ import {
   getPrevVisits,
   getNextVisits,
 } from '../../libs/microcms'
+import { recordPageView } from '../../libs/pageview'
 import type { Meta } from '../../types/meta'
 import { jstDatetime } from '../../utils/jstDatetime'
 import { stripHtmlTagsAndTruncate } from '../../utils/stripHtmlTags'
@@ -26,6 +27,17 @@ export default createRoute(async (c) => {
   const prevVisits = await getPrevVisits({ client, publishedAt })
   const url = new URL(c.req.url)
   const canonicalUrl = `${url.protocol}//${url.host}/visits/${id}`
+
+  // ページビュー記録（レスポンスをブロックしない）
+  c.executionCtx.waitUntil(
+    recordPageView({
+      db: c.env.DB,
+      pagePath: `/visits/${id}`,
+      contentId: id,
+      pageType: 'visit',
+      visit,
+    })
+  )
 
   const meta: Meta = {
     title: `${visit.title} - ${visit.shop.name} - 飯ログ`,

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,28 @@
+CREATE TABLE daily_pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_path TEXT NOT NULL,
+    content_id TEXT NOT NULL,
+    page_type TEXT NOT NULL,
+    date TEXT NOT NULL,
+    count INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(page_path, date)
+);
+
+CREATE INDEX idx_daily_pages_date ON daily_pages(date);
+CREATE INDEX idx_daily_pages_content ON daily_pages(content_id, page_type);
+
+CREATE TABLE popular_pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    page_path TEXT NOT NULL,
+    content_id TEXT NOT NULL,
+    page_type TEXT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    thumbnail_url TEXT NOT NULL DEFAULT '',
+    shop_name TEXT NOT NULL DEFAULT '',
+    total_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL,
+    UNIQUE(page_path)
+);
+
+CREATE INDEX idx_popular_pages_total ON popular_pages(total_count DESC);
+CREATE INDEX idx_popular_pages_type ON popular_pages(page_type, total_count DESC);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,12 +1,20 @@
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "meshi-log",
-  "main": "./dist/index.js",
-  "compatibility_date": "2025-10-02",
-  "compatibility_flags": [
-    "nodejs_compat"
-  ],
-  "assets": {
-    "directory": "./dist"
-  }
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "meshi-log",
+	"main": "./dist/index.js",
+	"compatibility_date": "2025-10-02",
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"assets": {
+		"directory": "./dist"
+	},
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "meshi-log-analytics",
+			"database_id": "f4bfc72d-62ab-45cd-9a6b-d5b14c347568",
+			"remote": true
+		}
+	]
 }


### PR DESCRIPTION
## Summary
- visitページアクセス時にD1(daily_pages/popular_pages)へページビューを記録（waitUntilで非同期）
- D1のpopular_pagesから人気記事ランキングを表示する `/popular` ページを追加
- ヘッダー・フッターに人気記事リンクを追加

## Test plan
- [x] `/visits/:id` にアクセスしてD1にページビューが記録されることを確認
- [x] `/popular` にアクセスしてランキングが表示されることを確認
- [x] ヘッダー・フッターの人気記事リンクが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)