### PR TITLE
feat: 店舗ジャンルを複数参照に対応（_genreフィールド使用）

### DIFF
--- a/app/components/AllShopsMap.tsx
+++ b/app/components/AllShopsMap.tsx
@@ -1,13 +1,19 @@
 import type { Shop } from '../types/microcms'
 import { raw } from 'hono/html'
+import { getGenreString } from '../utils/getGenreString'
 
 type Props = {
   shops: Shop[]
 }
 
 export const AllShopsMap = ({ shops }: Props) => {
-  // 座標を持つ店舗のみフィルタリング
-  const shopsWithCoords = shops.filter((shop) => shop.latitude && shop.longitude)
+  // 座標を持つ店舗のみフィルタリング + ジャンル文字列を事前に生成
+  const shopsWithCoords = shops
+    .filter((shop) => shop.latitude && shop.longitude)
+    .map((shop) => ({
+      ...shop,
+      genreString: getGenreString(shop._genre),
+    }))
 
   if (shopsWithCoords.length === 0) {
     return (
@@ -101,7 +107,7 @@ export const AllShopsMap = ({ shops }: Props) => {
                     </a>
                   </h3>
                   <p style="font-size: 12px; color: #666;">
-                    \${shop.area.name} - \${shop.genre.name}
+                    \${shop.area.name} - \${shop.genreString}
                   </p>
                   <p style="font-size: 12px; margin-top: 4px;">
                     \${shop.address}

--- a/app/components/ShopListCard.tsx
+++ b/app/components/ShopListCard.tsx
@@ -1,5 +1,6 @@
 import type { Shop } from '../types/microcms'
 import { Badge } from './Badge'
+import { getShopGenreString } from '../utils/getShopGenreString'
 
 type Props = {
   shop: Shop
@@ -19,7 +20,7 @@ export const ShopListCard = ({ shop }: Props) => {
       <div class="space-y-2 text-sm text-gray-600">
         <p>
           <span class="font-medium">ジャンル: </span>
-          {shop.genre.name}
+          {getShopGenreString(shop._genre)}
         </p>
         <p>
           <span class="font-medium">エリア: </span>

--- a/app/components/VisitListCard.tsx
+++ b/app/components/VisitListCard.tsx
@@ -1,6 +1,7 @@
 import { jstDatetime } from '../utils/jstDatetime'
 import type { Visit } from '../types/microcms'
 import { stripHtmlTagsAndTruncate } from '../utils/stripHtmlTags'
+import { getShopGenreString } from '../utils/getShopGenreString'
 
 type Props = {
   visit: Visit
@@ -27,7 +28,7 @@ export const VisitListCard = ({ visit }: Props) => {
           <div class="flex flex-wrap items-center gap-2 md:gap-4 text-sm text-gray-600 mb-3 md:mb-4">
             <time>{jstDatetime(visit.visit_date, 'YYYY年M月D日')}</time>
             <span>{visit.shop.area.name}</span>
-            <span>{visit.shop.genre.name}</span>
+            <span>{getShopGenreString(visit.shop._genre)}</span>
           </div>
 
           <p class="line-clamp-3 text-sm md:text-base text-gray-700">

--- a/app/routes/shops/[id].tsx
+++ b/app/routes/shops/[id].tsx
@@ -5,6 +5,7 @@ import { VisitListCard } from '../../components/VisitListCard'
 import { config } from '../../siteSettings'
 import { Pagination } from '../../components/Pagination'
 import type { Meta } from '../../types/meta'
+import { getShopGenreString } from '../../utils/getShopGenreString'
 
 export default createRoute(async (c) => {
   const id = c.req.param('id') || ''
@@ -15,7 +16,7 @@ export default createRoute(async (c) => {
   const offset = limit * (page - 1)
   const visits = await getVisits({
     client,
-    queries: { limit: limit, offset: offset, filters: `shop[equals]${id}` },
+    queries: { limit: limit, depth: 2, offset: offset, filters: `shop[equals]${id}` },
   })
   const visitsCount = visits.totalCount
 
@@ -39,7 +40,7 @@ export default createRoute(async (c) => {
         <div class="space-y-3 text-gray-700">
           <div>
             <span class="font-medium">ジャンル: </span>
-            {shop.genre.name}
+            {getShopGenreString(shop._genre)}
           </div>
 
           <div>

--- a/app/routes/shops/map.tsx
+++ b/app/routes/shops/map.tsx
@@ -12,7 +12,7 @@ export default createRoute(async (c) => {
   const shops = await getAllShops({
     client,
     queries: {
-      fields: 'id,name,address,latitude,longitude,area,genre,is_recommended',
+      fields: 'id,name,address,latitude,longitude,area,_genre,is_recommended',
     },
   })
 
@@ -36,8 +36,10 @@ export default createRoute(async (c) => {
 
   const genreShopCount: Record<string, number> = {}
   for (const s of shops) {
-    if (!genreShopCount[s.genre.name]) genreShopCount[s.genre.name] = 0
-    genreShopCount[s.genre.name]++
+    for (const genre of s._genre) {
+      if (!genreShopCount[genre.name]) genreShopCount[genre.name] = 0
+      genreShopCount[genre.name]++
+    }
   }
 
   const sortedAreaStats = Object.entries(areaShopCount).sort((a, b) => b[1] - a[1])

--- a/app/types/microcms.ts
+++ b/app/types/microcms.ts
@@ -19,7 +19,8 @@ export interface Shop extends MicroCMSContentId, MicroCMSDate {
   latitude: number
   longitude: number
   area: Area
-  genre: Genre
+  genre: Genre[]
+  _genre: Genre[]
   memo: string // textArea (required)
   is_recommended: boolean // boolean (required)
   rating?: number // number (optional)

--- a/app/utils/buildShopFilterCondition.ts
+++ b/app/utils/buildShopFilterCondition.ts
@@ -11,7 +11,7 @@ export const buildShopFilterCondition = (params: ShopFilterParams): string => {
     filterCondition.push(`area[equals]${params.area_id}`)
   }
   if (params.genre_id) {
-    filterCondition.push(`genre[equals]${params.genre_id}`)
+    filterCondition.push(`_genre[contains]${params.genre_id}`)
   }
   if (params.is_recommended) {
     filterCondition.push(`is_recommended[equals]true`)

--- a/app/utils/getGenreString.ts
+++ b/app/utils/getGenreString.ts
@@ -1,0 +1,5 @@
+import type { Genre, Shop } from '../types/microcms'
+
+export const getGenreString = (genre: Genre[]) => {
+  return genre.map((g) => g.name).join(',')
+}

--- a/app/utils/getShopGenreString.ts
+++ b/app/utils/getShopGenreString.ts
@@ -1,0 +1,5 @@
+import type { Genre } from '../types/microcms'
+
+export const getShopGenreString = (genre: Genre[]) => {
+  return genre.map((g) => g.name).join(',')
+}


### PR DESCRIPTION
  - Shop型に_genreフィールド（Genre[]）を追加
  - getGenreString, getShopGenreStringユーティリティを追加
  - フィルター条件をgenre[equals]から_genre[contains]に変更
  - 全ての表示コンポーネントで_genreを使用
  - マップページの統計情報を複数ジャンル対応に修正

  開発環境でのテスト用。後でgenreフィールドを削除して_genreに一本化予定。

#86 