### PR TITLE
Feat/mcp shop registration

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,4 +1,5 @@
 import type {} from 'hono'
+import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider'
 import type { Meta } from './types/meta'
 
 interface Head {
@@ -16,6 +17,9 @@ declare module 'hono' {
       TURNSTILE_SECRET_KEY: string
       EMAIL: SendEmail
       NOTIFICATION_EMAIL: string
+      ADMIN_PASSWORD: string
+      OAUTH_KV: KVNamespace
+      OAUTH_PROVIDER: OAuthHelpers
     }
   }
   interface ContextRenderer {

--- a/app/islands/ShopFilterForm.tsx
+++ b/app/islands/ShopFilterForm.tsx
@@ -140,6 +140,7 @@ const FormContent = ({ areas, genres, prefectures, initialFilters }: ShopFilterF
             <input
               type="text"
               name="q"
+              autocomplete="off"
               value={initialFilters.q || ''}
               placeholder="店名で検索..."
               class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/app/libs/admin-mcp-app.ts
+++ b/app/libs/admin-mcp-app.ts
@@ -1,0 +1,29 @@
+import { Hono } from 'hono'
+import type { Env } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+import { StreamableHTTPTransport } from '@hono/mcp'
+import { getMcpServer } from '../routes/mcp'
+
+const adminApp = new Hono<Env>()
+
+adminApp.all('/mcp/admin', async (c) => {
+  const mcpServer = await getMcpServer(c, { includeWriteTools: true })
+  const transport = new StreamableHTTPTransport()
+  await mcpServer.connect(transport)
+  return transport.handleRequest(c)
+})
+
+adminApp.onError((err, c) => {
+  console.log(err.message)
+  if (err instanceof HTTPException && err.res) return err.res
+  return c.json(
+    {
+      jsonrpc: '2.0',
+      error: { code: -32603, message: 'Internal server error' },
+      id: null,
+    },
+    500
+  )
+})
+
+export default adminApp

--- a/app/libs/microcms.ts
+++ b/app/libs/microcms.ts
@@ -135,23 +135,27 @@ export const getNextVisits = async ({ client, publishedAt }: ClientWithPublished
 // エリア新規作成
 export const createArea = async ({
   client,
+  contentId,
   body,
 }: {
   client: MicroCMSClient
+  contentId?: string
   body: { code: string; name: string }
 }) => {
-  return await client.create({ endpoint: 'area', content: body })
+  return await client.create({ endpoint: 'area', contentId, content: body })
 }
 
 // ジャンル新規作成
 export const createGenre = async ({
   client,
+  contentId,
   body,
 }: {
   client: MicroCMSClient
+  contentId?: string
   body: { name: string }
 }) => {
-  return await client.create({ endpoint: 'genre', content: body })
+  return await client.create({endpoint: 'genre', contentId, content: body })
 }
 
 // 店舗新規作成
@@ -171,12 +175,14 @@ export type CreateShopBody = {
 
 export const createShop = async ({
   client,
+  contentId,
   body,
 }: {
   client: MicroCMSClient
+  contentId?: string
   body: CreateShopBody
 }) => {
-  return await client.create({ endpoint: 'shop', content: body })
+  return await client.create({ endpoint: 'shop', contentId, content: body })
 }
 
 export const getMicroCMSSchema = async ({ serviceDomain, apiKey }: ClientConfig) => {

--- a/app/libs/microcms.ts
+++ b/app/libs/microcms.ts
@@ -132,6 +132,53 @@ export const getNextVisits = async ({ client, publishedAt }: ClientWithPublished
   })
 }
 
+// エリア新規作成
+export const createArea = async ({
+  client,
+  body,
+}: {
+  client: MicroCMSClient
+  body: { code: string; name: string }
+}) => {
+  return await client.create({ endpoint: 'area', content: body })
+}
+
+// ジャンル新規作成
+export const createGenre = async ({
+  client,
+  body,
+}: {
+  client: MicroCMSClient
+  body: { name: string }
+}) => {
+  return await client.create({ endpoint: 'genre', content: body })
+}
+
+// 店舗新規作成
+export type CreateShopBody = {
+  name: string
+  address: string
+  latitude: number
+  longitude: number
+  area: string
+  area_code: string
+  genre: string[]
+  memo: string
+  is_recommended: boolean
+  rating?: number
+  nearest_station?: string
+}
+
+export const createShop = async ({
+  client,
+  body,
+}: {
+  client: MicroCMSClient
+  body: CreateShopBody
+}) => {
+  return await client.create({ endpoint: 'shop', content: body })
+}
+
 export const getMicroCMSSchema = async ({ serviceDomain, apiKey }: ClientConfig) => {
   const ret = []
   const endPoints = ['genre', 'area', 'shop', 'visits']

--- a/app/routes/mcp.ts
+++ b/app/routes/mcp.ts
@@ -271,14 +271,16 @@ export const getMcpServer = async (c: Context<Env>, options: McpServerOptions = 
       {
         title: 'Create Area',
         description:
-          'Create a new area in microCMS. `code` is the JIS municipality code (e.g. "13101" for Chiyoda-ku).',
+          'Create a new area in microCMS. `code` is the JIS municipality code (e.g. "13101" for Chiyoda-ku). `id` is the contentId, conventionally a romaji slug derived from the area name (e.g. "tokyo-to-machida-shi" for 東京都町田市, "tokyo-to-chiyoda-ku" for 東京都千代田区). Always specify `id` following this convention. IMPORTANT: Before calling this tool, you MUST look up the precise JIS municipality code via web search (search e.g. "東京都町田市 JIS 市区町村コード") — do NOT guess or infer the code from memory.',
         inputSchema: {
+          id: z.string().min(1),
           code: z.string().min(1),
           name: z.string().min(1),
         },
       },
-      async (params: { code: string; name: string }) => {
-        const result = await createArea({ client, body: params })
+      async (params: { id: string; code: string; name: string }) => {
+        const { id, ...body } = params
+        const result = await createArea({ client, contentId: id, body })
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         }
@@ -289,13 +291,16 @@ export const getMcpServer = async (c: Context<Env>, options: McpServerOptions = 
       'create_genre',
       {
         title: 'Create Genre',
-        description: 'Create a new genre in microCMS.',
+        description:
+          'Create a new genre in microCMS. Optionally specify `id` for a custom contentId; if omitted, microCMS auto-generates one.',
         inputSchema: {
+          id: z.string().optional(),
           name: z.string().min(1),
         },
       },
-      async (params: { name: string }) => {
-        const result = await createGenre({ client, body: params })
+      async (params: { id?: string; name: string }) => {
+        const { id, ...body } = params
+        const result = await createGenre({ client, contentId: id, body })
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         }
@@ -307,8 +312,9 @@ export const getMcpServer = async (c: Context<Env>, options: McpServerOptions = 
       {
         title: 'Create Shop',
         description:
-          'Create a new shop in microCMS. `area` is the area content ID, `genre` is an array of genre content IDs. `area_code` is the JIS municipality code.',
+          'Create a new shop in microCMS. `area` is the area content ID, `genre` is an array of genre content IDs. `area_code` is the JIS municipality code. Optionally specify `id` for a custom contentId (e.g. a URL-friendly slug); if omitted, microCMS auto-generates one. IMPORTANT: Before calling this tool, you MUST look up both the precise `address` and `latitude`/`longitude` via web search or the "Searching for place" tool — search for the actual shop name and verify the address and coordinates from the results. Do NOT guess, infer, or use approximate values.',
         inputSchema: {
+          id: z.string().optional(),
           name: z.string().min(1),
           address: z.string().min(1),
           latitude: z.number(),
@@ -317,12 +323,13 @@ export const getMcpServer = async (c: Context<Env>, options: McpServerOptions = 
           area_code: z.string().min(1),
           genre: z.array(z.string().min(1)).min(1),
           memo: z.string(),
-          is_recommended: z.boolean(),
-          rating: z.number().min(0).max(5).optional(),
+          is_recommended: z.boolean().default(false),
+          rating: z.number().min(0).max(5).optional().default(4),
           nearest_station: z.string().optional(),
         },
       },
       async (params: {
+        id?: string
         name: string
         address: string
         latitude: number
@@ -335,7 +342,8 @@ export const getMcpServer = async (c: Context<Env>, options: McpServerOptions = 
         rating?: number
         nearest_station?: string
       }) => {
-        const result = await createShop({ client, body: params })
+        const { id, ...body } = params
+        const result = await createShop({ client, contentId: id, body })
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         }

--- a/app/routes/mcp.ts
+++ b/app/routes/mcp.ts
@@ -8,6 +8,9 @@ import {
   getGenres,
   getShops,
   getShopDetail,
+  createArea,
+  createGenre,
+  createShop,
 } from '../libs/microcms'
 import { getPopularPages } from '../libs/pageview'
 import { StreamableHTTPTransport } from '@hono/mcp'
@@ -22,7 +25,11 @@ import { buildShopFilterCondition } from '../utils/buildShopFilterCondition'
 
 const limit = config.serachPerPage
 
-export const getMcpServer = async (c: Context<Env>) => {
+type McpServerOptions = {
+  includeWriteTools?: boolean
+}
+
+export const getMcpServer = async (c: Context<Env>, options: McpServerOptions = {}) => {
   const serviceDomain = c.env.SERVICE_DOMAIN
   const apiKey = c.env.API_KEY
   const client = getMicroCMSClient(c)
@@ -257,6 +264,85 @@ export const getMcpServer = async (c: Context<Env>) => {
       }
     }
   )
+
+  if (options.includeWriteTools) {
+    server.registerTool(
+      'create_area',
+      {
+        title: 'Create Area',
+        description:
+          'Create a new area in microCMS. `code` is the JIS municipality code (e.g. "13101" for Chiyoda-ku).',
+        inputSchema: {
+          code: z.string().min(1),
+          name: z.string().min(1),
+        },
+      },
+      async (params: { code: string; name: string }) => {
+        const result = await createArea({ client, body: params })
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        }
+      }
+    )
+
+    server.registerTool(
+      'create_genre',
+      {
+        title: 'Create Genre',
+        description: 'Create a new genre in microCMS.',
+        inputSchema: {
+          name: z.string().min(1),
+        },
+      },
+      async (params: { name: string }) => {
+        const result = await createGenre({ client, body: params })
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        }
+      }
+    )
+
+    server.registerTool(
+      'create_shop',
+      {
+        title: 'Create Shop',
+        description:
+          'Create a new shop in microCMS. `area` is the area content ID, `genre` is an array of genre content IDs. `area_code` is the JIS municipality code.',
+        inputSchema: {
+          name: z.string().min(1),
+          address: z.string().min(1),
+          latitude: z.number(),
+          longitude: z.number(),
+          area: z.string().min(1),
+          area_code: z.string().min(1),
+          genre: z.array(z.string().min(1)).min(1),
+          memo: z.string(),
+          is_recommended: z.boolean(),
+          rating: z.number().min(0).max(5).optional(),
+          nearest_station: z.string().optional(),
+        },
+      },
+      async (params: {
+        name: string
+        address: string
+        latitude: number
+        longitude: number
+        area: string
+        area_code: string
+        genre: string[]
+        memo: string
+        is_recommended: boolean
+        rating?: number
+        nearest_station?: string
+      }) => {
+        const result = await createShop({ client, body: params })
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        }
+      }
+    )
+  }
+
   return server
 }
 

--- a/app/routes/oauth/authorize.tsx
+++ b/app/routes/oauth/authorize.tsx
@@ -1,0 +1,85 @@
+import { createRoute } from 'honox/factory'
+
+const Page = ({
+  clientName,
+  scope,
+  error,
+}: {
+  clientName: string
+  scope: string
+  error?: string
+}) => (
+  <html lang="ja">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <meta name="robots" content="noindex,nofollow" />
+      <title>meshi-log MCP Authorize</title>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+            body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 420px; margin: 64px auto; padding: 24px; color: #222; }
+            h1 { font-size: 1.25rem; margin-bottom: 1rem; }
+            .info { background: #f5f5f5; padding: 12px 16px; border-radius: 6px; font-size: 0.9rem; margin-bottom: 16px; }
+            .info dt { font-weight: 600; color: #555; }
+            .info dd { margin: 0 0 8px 0; word-break: break-all; }
+            input[type=password] { width: 100%; padding: 10px; font-size: 1rem; border: 1px solid #ccc; border-radius: 6px; box-sizing: border-box; }
+            button { width: 100%; padding: 12px; margin-top: 12px; font-size: 1rem; background: #111; color: #fff; border: none; border-radius: 6px; cursor: pointer; }
+            button:hover { background: #333; }
+            .error { color: #c33; margin-bottom: 12px; font-size: 0.9rem; }
+          `,
+        }}
+      />
+    </head>
+    <body>
+      <h1>MCP Authorization</h1>
+      <dl class="info">
+        <dt>Client</dt>
+        <dd>{clientName}</dd>
+        <dt>Scope</dt>
+        <dd>{scope || '(none)'}</dd>
+      </dl>
+      {error && <p class="error">{error}</p>}
+      <form method="post">
+        <input type="password" name="password" placeholder="Admin password" autofocus required />
+        <button type="submit">Authorize</button>
+      </form>
+    </body>
+  </html>
+)
+
+export const GET = createRoute(async (c) => {
+  const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
+  const client = await c.env.OAUTH_PROVIDER.lookupClient(oauthReqInfo.clientId)
+  const clientName = client?.clientName ?? oauthReqInfo.clientId
+  const scope = oauthReqInfo.scope.join(' ')
+  return c.html(<Page clientName={clientName} scope={scope} />)
+})
+
+export const POST = createRoute(async (c) => {
+  const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
+  const formData = await c.req.formData()
+  const password = formData.get('password')
+
+  if (typeof password !== 'string' || password !== c.env.ADMIN_PASSWORD) {
+    const client = await c.env.OAUTH_PROVIDER.lookupClient(oauthReqInfo.clientId)
+    const clientName = client?.clientName ?? oauthReqInfo.clientId
+    return c.html(
+      <Page
+        clientName={clientName}
+        scope={oauthReqInfo.scope.join(' ')}
+        error="パスワードが正しくありません"
+      />,
+      401
+    )
+  }
+
+  const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
+    request: oauthReqInfo,
+    userId: 'admin',
+    scope: oauthReqInfo.scope,
+    metadata: {},
+    props: {},
+  })
+  return c.redirect(redirectTo)
+})

--- a/app/server.ts
+++ b/app/server.ts
@@ -1,11 +1,23 @@
 import { showRoutes } from 'hono/dev'
 import { createApp } from 'honox/server'
+import { OAuthProvider } from '@cloudflare/workers-oauth-provider'
 import mcpApp from './routes/mcp'
+import adminMcpApp from './libs/admin-mcp-app'
 
-const app = createApp()
+const honoxApp = createApp()
 
-app.route('/mcp', mcpApp)
+honoxApp.route('/mcp', mcpApp)
 
-showRoutes(app)
+showRoutes(honoxApp)
 
-export default app
+export default new OAuthProvider({
+  apiRoute: '/mcp/admin',
+  apiHandler: adminMcpApp,
+  defaultHandler: honoxApp,
+  authorizeEndpoint: '/oauth/authorize',
+  tokenEndpoint: '/oauth/token',
+  clientRegistrationEndpoint: '/oauth/register',
+  scopesSupported: ['mcp:write'],
+  accessTokenTTL: 3600,
+  refreshTokenTTL: 30 * 24 * 3600,
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
+    "@cloudflare/workers-oauth-provider": "^0.4.0",
     "@hono/mcp": "^0.2.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dayjs": "^1.11.19",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ command }) => {
     },
     build: {
       rollupOptions: {
-        external: ['shiki', 'cloudflare:email'],
+        external: ['shiki', 'cloudflare:email', 'cloudflare:workers'],
       },
     },
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,25 +1,29 @@
 {
-	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "meshi-log",
-	"main": "./dist/index.js",
-	"compatibility_date": "2025-10-02",
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
-	"assets": {
-		"directory": "./dist"
-	},
-	"send_email": [
-		{
-			"name": "EMAIL"
-		}
-	],
-	"d1_databases": [
-		{
-			"binding": "DB",
-			"database_name": "meshi-log-db",
-			"database_id": "0dd6b9b2-c2c3-4b61-a769-9fc99086a112",
-			"remote": true
-		}
-	]
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "meshi-log",
+  "main": "./dist/index.js",
+  "compatibility_date": "2025-10-02",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "./dist",
+  },
+  "send_email": [
+    {
+      "name": "EMAIL",
+    },
+  ],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "meshi-log-db",
+      "database_id": "0dd6b9b2-c2c3-4b61-a769-9fc99086a112",
+      "remote": true,
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "OAUTH_KV",
+      "id": "7ec3029befa84fabb270604c30c9c346",
+    },
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -142,6 +142,11 @@
   resolved "https://registry.yarnpkg.com/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz#5240fb60d9f2879d70e1a106fbcea2a3f9295efe"
   integrity sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==
 
+"@cloudflare/workers-oauth-provider@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.4.0.tgz#93b6f91b6a7c2bbfc1d3479d791ad40a06a2c951"
+  integrity sha512-UtbV8hjC2NloB+Ds6J6v/9HiG8rx8MbdeYGCyFwOACT5vANWzDL6SKo3W5UZymsXiameAgC7jAmtUx4cc+Qpaw==
+
 "@cloudflare/workers-types@^4.20260404.1":
   version "4.20260404.1"
   resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-4.20260404.1.tgz#418821c261a5000e83d5c0b83db2cfda8bc7ee1e"


### PR DESCRIPTION
## Summary                                          

  - 書き込み系MCPツール用のエンドポイント `/mcp/admin` を追加（OAuth 2.1 で保護）                                   
  - microCMSの `area` / `genre` / `shop` を新規作成するツール（`create_area`, `create_genre`, `create_shop`）を実装
  - `@cloudflare/workers-oauth-provider` でラップし、`/oauth/authorize` にパスワード認証UIを追加                    
                                                                                                                    
  ## 変更内容                                                                                                       
                                                                                                                    
  ### MCP書き込みエンドポイント                                                                                     
   
  - `app/libs/admin-mcp-app.ts`: `/mcp/admin` 用のHonoアプリ。`getMcpServer(c, { includeWriteTools: true })`        
  で書き込みツールを有効化                            
  - `app/routes/mcp.ts`: `getMcpServer` に `includeWriteTools` オプションを追加。`create_area` / `create_genre` /   
  `create_shop` を登録                                                                                              
    - 各ツールの `id`（contentId）はクライアント側で命名規則に沿って指定可能（例: `tokyo-to-machida-shi`）
    - `create_area` / `create_shop`                                                                                 
  の説明文で、JISコード・住所・緯度経度はWeb検索で検証してから渡すよう明示（推測禁止）                              
  - `app/libs/microcms.ts`: `createArea` / `createGenre` / `createShop` を追加                                      
                                                                                                                    
  ### OAuth                                           
                                                                                                                    
  - `app/server.ts`: エントリポイントを `OAuthProvider` でラップし、`apiRoute: /mcp/admin` を保護対象に             
  - `app/routes/oauth/authorize.tsx`: パスワード認証の認可UI（`ADMIN_PASSWORD` シークレットで照合）
  - `wrangler.jsonc`: `OAUTH_KV` Namespace バインディングを追加                                                     
                                                                                                                    
 