### PR TITLE
Add shop noindex field

### DIFF
--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -10,6 +10,7 @@ export default jsxRenderer(({ children, meta }) => {
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>{meta?.title}</title>
+        {meta?.noindex && <meta name="robots" content="noindex" />}
         <link rel="canonical" href={meta?.canonicalUrl} />
         <meta name="description" content={meta?.description} />
         <meta name="keywords" content={meta?.keywords} />

--- a/app/routes/shops/[id].tsx
+++ b/app/routes/shops/[id].tsx
@@ -29,6 +29,7 @@ export default createRoute(async (c) => {
     canonicalUrl: canonicalUrl,
     ogpType: 'website' as const,
     ogpUrl: canonicalUrl,
+    noindex: shop.noindex,
   }
 
   return c.render(

--- a/app/routes/sitemap.ts
+++ b/app/routes/sitemap.ts
@@ -8,6 +8,7 @@ export default createRoute(async (c) => {
   const allVisits = await getAllVisits({ client: client, queries: { orders: '-visit_date' } })
   const urls = []
   for (const visit of allVisits) {
+    if (visit.shop.noindex) continue
     const jst = jstDatetime(visit.updatedAt).split('T')[0]
     urls.push(`
   <url>

--- a/app/routes/visits/[id].tsx
+++ b/app/routes/visits/[id].tsx
@@ -124,6 +124,7 @@ export default createRoute(async (c) => {
     ogpType: 'article' as const,
     ogpImage: visit.thumbnail?.url,
     ogpUrl: canonicalUrl,
+    noindex: visit.shop.noindex,
   }
 
   return c.render(

--- a/app/types/meta.ts
+++ b/app/types/meta.ts
@@ -6,4 +6,5 @@ export interface Meta {
   ogpUrl?: string
   ogpImage?: string
   ogpType?: 'website' | 'article'
+  noindex?: boolean
 }

--- a/app/types/microcms.ts
+++ b/app/types/microcms.ts
@@ -24,6 +24,7 @@ export interface Shop extends MicroCMSContentId, MicroCMSDate {
   memo: string // textArea (required)
   is_recommended: boolean // boolean (required)
   rating: number // number (optional)
+  noindex: boolean
   nearest_station?: string // 最寄駅 (optional)
 }
 


### PR DESCRIPTION
## 概要

店舗（shop）単位で、特定の店の訪問記事をGoogle検索結果から除外（noindex）する機能を追加する。

サイト内の一覧・検索・人気・フィードには従来どおり表示したまま、Google検索だけを除外する方針である。

## 変更内容

* app/types/microcms.ts: Shop に noindex: boolean（必須）を追加
* app/types/meta.ts: Meta に noindex?: boolean を追加
* app/routes/_renderer.tsx: noindex が true のとき  を出力（nofollowは付けない）
* app/routes/visits/[id].tsx: meta に noindex: visit.shop.noindex をセット
* app/routes/shops/[id].tsx: meta に noindex: shop.noindex をセット
* app/routes/sitemap.ts: visit.shop.noindex が true の訪問記事をsitemapから除外

## 補足

* microCMSの shop に noindex フィールド（真偽値）を追加済みである
* 既にインデックス済みのページはGoogleの再クロールまで検索結果に残るため、即時削除が必要な場合はSearch Consoleの削除ツールを併用する

Closes #115