### PR TITLE
perf: microCMSデータ転送量の削減（fields絞り込み＋画像最適化）

### DIFF
--- a/app/components/VisitListCard.tsx
+++ b/app/components/VisitListCard.tsx
@@ -2,6 +2,7 @@ import { jstDatetime } from '../utils/jstDatetime'
 import type { Visit } from '../types/microcms'
 import { stripHtmlTagsAndTruncate } from '../utils/stripHtmlTags'
 import { getShopGenreString } from '../utils/getShopGenreString'
+import { getMicrocmsImageUrl } from '../utils/microcmsImageUrl'
 
 type Props = {
   visit: Visit
@@ -13,7 +14,7 @@ export const VisitListCard = ({ visit }: Props) => {
       <a href={`/visits/${visit.id}`} class="flex flex-col md:flex-row gap-4 md:gap-6">
         <div class="flex-shrink-0 w-full md:w-48">
           <img
-            src={visit.thumbnail.url}
+            src={getMicrocmsImageUrl(visit.thumbnail.url, { w: 400, fm: 'webp', q: 80 })}
             alt={visit.title}
             width={visit.thumbnail.width}
             height={visit.thumbnail.height}

--- a/app/libs/microcms.ts
+++ b/app/libs/microcms.ts
@@ -117,7 +117,12 @@ export const getVisitDetail = async ({ client, contentId, queries }: ClientWithC
 export const getPrevVisits = async ({ client, publishedAt }: ClientWithPublishedAt) => {
   return await client.getList<Visit>({
     endpoint: 'visits',
-    queries: { limit: 1, filters: `publishedAt[less_than]${publishedAt}`, orders: '-publishedAt' },
+    queries: {
+      limit: 1,
+      filters: `publishedAt[less_than]${publishedAt}`,
+      orders: '-publishedAt',
+      fields: 'id,title',
+    },
   })
 }
 
@@ -128,6 +133,7 @@ export const getNextVisits = async ({ client, publishedAt }: ClientWithPublished
       limit: 1,
       filters: `publishedAt[greater_than]${publishedAt}`,
       orders: 'publishedAt',
+      fields: 'id,title',
     },
   })
 }

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -28,7 +28,13 @@ export default createRoute(async (c) => {
 
   const visitsResponse = await getVisits({
     client,
-    queries: { limit: limit, offset: offset, depth: 2, orders: '-publishedAt' },
+    queries: {
+      limit: limit,
+      offset: offset,
+      depth: 2,
+      orders: '-publishedAt',
+      fields: 'id,title,thumbnail,visit_date,memo,shop.name,shop.area.name,shop.genre.name',
+    },
   })
   const totalCount = visitsResponse.totalCount
   const visits = visitsResponse.contents

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -16,6 +16,8 @@ export default createRoute(async (c) => {
   const queries: MicroCMSQueries = {
     limit: limit,
     q: keyword,
+    depth: 2,
+    fields: 'id,title,thumbnail,visit_date,memo,shop.name,shop.area.name,shop.genre.name',
   }
   const url = new URL(c.req.url)
   const canonicalUrl = `${url.protocol}//${url.host}/`

--- a/app/routes/shops/[id].tsx
+++ b/app/routes/shops/[id].tsx
@@ -16,7 +16,13 @@ export default createRoute(async (c) => {
   const offset = limit * (page - 1)
   const visits = await getVisits({
     client,
-    queries: { limit: limit, depth: 2, offset: offset, filters: `shop[equals]${id}` },
+    queries: {
+      limit: limit,
+      depth: 2,
+      offset: offset,
+      filters: `shop[equals]${id}`,
+      fields: 'id,title,thumbnail,visit_date,memo,shop.name,shop.area.name,shop.genre.name',
+    },
   })
   const visitsCount = visits.totalCount
 

--- a/app/routes/shops/index.tsx
+++ b/app/routes/shops/index.tsx
@@ -37,6 +37,7 @@ export default createRoute(async (c) => {
       orders: 'area_code',
       offset: offset,
       filters: filterString.length > 0 ? filterString : undefined,
+      fields: 'id,name,is_recommended,nearest_station,memo,area.name,genre.name',
     },
   })
 
@@ -45,7 +46,7 @@ export default createRoute(async (c) => {
     queries: {
       q: searchQuery || undefined,
       depth: 1,
-      fields: 'id,area,area_code,genre',
+      fields: 'id,area_code,area.id,area.name,genre.id,genre.name',
       filters: filterString.length > 0 ? filterString : undefined,
     },
   })

--- a/app/routes/sitemap.ts
+++ b/app/routes/sitemap.ts
@@ -5,7 +5,10 @@ import { getMicroCMSClient, getAllVisits, getAllShops } from '../libs/microcms'
 
 export default createRoute(async (c) => {
   const client = getMicroCMSClient(c)
-  const allVisits = await getAllVisits({ client: client, queries: { orders: '-visit_date' } })
+  const allVisits = await getAllVisits({
+    client: client,
+    queries: { orders: '-visit_date', fields: 'id,updatedAt,shop.noindex' },
+  })
   const urls = []
   for (const visit of allVisits) {
     if (visit.shop.noindex) continue
@@ -17,7 +20,10 @@ export default createRoute(async (c) => {
     <priority>0.8</priority>
   </url>`)
   }
-  const allShops = await getAllShops({ client: client, queries: { orders: '-publishedAt' } })
+  const allShops = await getAllShops({
+    client: client,
+    queries: { orders: '-publishedAt', fields: 'id,publishedAt,noindex' },
+  })
   for (const shop of allShops) {
     if (shop.noindex) continue
     const jst = jstDatetime(shop.publishedAt).split('T')[0]

--- a/app/utils/microcmsImageUrl.ts
+++ b/app/utils/microcmsImageUrl.ts
@@ -1,0 +1,17 @@
+type ImageOptions = {
+  w?: number
+  h?: number
+  fm?: 'webp' | 'jpg'
+  q?: number
+}
+
+// microCMSの画像APIパラメータ（fm/w/h/q）を付与して配信サイズを縮小する
+// 例: getMicrocmsImageUrl(url, { w: 400, fm: 'webp', q: 80 })
+export const getMicrocmsImageUrl = (url: string, opts: ImageOptions = {}): string => {
+  const u = new URL(url)
+  if (opts.w) u.searchParams.set('w', String(opts.w))
+  if (opts.h) u.searchParams.set('h', String(opts.h))
+  if (opts.fm) u.searchParams.set('fm', opts.fm)
+  if (opts.q) u.searchParams.set('q', String(opts.q))
+  return u.toString()
+}


### PR DESCRIPTION
microCMSのデータ転送量を削減する低リスク施策。表示結果は変更前と同一。

## 変更内容
- 一覧取得に `fields`（ドット記法でリレーション先まで）を付与し、未使用フィールドの転送を削減（index/search/shops/[id]/shops/index/sitemap）
- `search.tsx` に `depth:2` を明示追加（エリア名表示の潜在不具合も修正）
- `getPrevVisits`/`getNextVisits` を `id,title` のみ取得に
- サムネ画像を `?fm=webp&w=400&q=80` で配信（`getMicrocmsImageUrl` ヘルパー追加）

Cache APIによるレスポンスキャッシュは別途 #122 に記録。

🤖 Generated with [Claude Code](https://claude.com/claude-code)