### PR TITLE
perf: 公開ページのCloudflare Cache APIキャッシュ（TTL 10分）

### DIFF
--- a/app/islands/PageViewBeacon.tsx
+++ b/app/islands/PageViewBeacon.tsx
@@ -1,0 +1,26 @@
+import type { FC } from 'hono/jsx'
+import { useEffect } from 'hono/jsx'
+
+type Props = {
+  id: string
+}
+
+/**
+ * ページ表示時に一度だけ /api/pageview へPVビーコンを送る。
+ * 共有エッジキャッシュ済みのHTMLでもブラウザ側でJSが動くため、
+ * キャッシュと独立してPVを計測できる。
+ */
+export const PageViewBeacon: FC<Props> = ({ id }) => {
+  useEffect(() => {
+    fetch('/api/pageview', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id }),
+      keepalive: true,
+    }).catch(() => {
+      // 計測失敗はUXに影響させない
+    })
+  }, [])
+
+  return null
+}

--- a/app/libs/cache.ts
+++ b/app/libs/cache.ts
@@ -1,0 +1,71 @@
+import type { MiddlewareHandler } from 'hono'
+
+// キャッシュTTL（秒）: 10分
+const CACHE_MAX_AGE = 600
+
+// `caches.default` は Cloudflare Workers 拡張。DOM lib の CacheStorage 型と
+// 衝突して `default` が見えないため、必要なメソッドのみを明示して参照する。
+type EdgeCache = {
+  match(request: Request): Promise<Response | undefined>
+  put(request: Request, response: Response): Promise<void>
+}
+const getEdgeCache = (): EdgeCache => (caches as unknown as { default: EdgeCache }).default
+
+/**
+ * 公開GETページをエッジ共有キャッシュ（caches.default）の対象にするか判定する。
+ * 対象: /, /shops, /shops/*, /visits/*（draft除く）, /sitemap, /feed.atom
+ */
+export const isCacheable = (path: string): boolean => {
+  if (path === '/' || path === '/shops' || path === '/sitemap' || path === '/feed.atom') {
+    return true
+  }
+  if (path === '/visits/draft') return false
+  if (path.startsWith('/visits/')) return true
+  if (path.startsWith('/shops/')) return true
+  return false
+}
+
+/**
+ * Cloudflare Cache API による公開ページのレスポンスキャッシュ（TTL方式）。
+ * ヒット時は microCMS を一切呼ばずキャッシュHTMLを返す。
+ * ミス時はハンドラ結果を保存（status 200 かつ Set-Cookie を持たない場合のみ）。
+ */
+export const responseCache: MiddlewareHandler = async (c, next) => {
+  // dev等で Cache API / executionCtx が無い環境は素通り
+  if (typeof caches === 'undefined' || !c.executionCtx) {
+    return next()
+  }
+  if (c.req.method !== 'GET' || !isCacheable(c.req.path)) {
+    return next()
+  }
+
+  const cache = getEdgeCache()
+  const key = c.req.raw
+
+  const hit = await cache.match(key)
+  if (hit) {
+    return hit
+  }
+
+  await next()
+
+  const res = c.res
+  if (!res || res.status !== 200) return
+  if (res.headers.has('Set-Cookie')) return
+
+  // 保存用クローンに Cache-Control を付与
+  const toCache = res.clone()
+  toCache.headers.set('Cache-Control', `public, max-age=${CACHE_MAX_AGE}`)
+  // クライアント/エッジ双方が同じTTLでキャッシュできるよう元レスポンスにも付与
+  c.res.headers.set('Cache-Control', `public, max-age=${CACHE_MAX_AGE}`)
+
+  c.executionCtx.waitUntil(
+    (async () => {
+      try {
+        await cache.put(key, toCache)
+      } catch {
+        // Set-Cookie等で put が throw しても無視
+      }
+    })()
+  )
+}

--- a/app/libs/pageview.ts
+++ b/app/libs/pageview.ts
@@ -10,12 +10,17 @@ export type PopularPage = {
   total_count: number
 }
 
-type PageViewParams = {
+type SeedPageViewMetaParams = {
   db: D1Database
   pagePath: string
   contentId: string
   pageType: string
   visit: Visit
+}
+
+type IncrementPageViewParams = {
+  db: D1Database
+  contentId: string
 }
 
 export const getPopularPages = async (db: D1Database, limit = 10): Promise<PopularPage[]> => {
@@ -32,46 +37,62 @@ export const getPopularPages = async (db: D1Database, limit = 10): Promise<Popul
   return result.results
 }
 
-export const recordPageView = async ({
+/**
+ * popular_pages にメタ情報（title/サムネ/店名）のみを seed/更新する。
+ * カウントは増やさない（カウントはクライアントビーコンが担う）。
+ * microCMS由来の信頼値のみを書き込むため、サーバーレンダリング時に呼ぶ。
+ */
+export const seedPageViewMeta = async ({
   db,
   pagePath,
   contentId,
   pageType,
   visit,
-}: PageViewParams) => {
-  const today = new Date().toISOString().split('T')[0]
+}: SeedPageViewMetaParams) => {
   const now = new Date().toISOString()
+  await db
+    .prepare(
+      `INSERT INTO popular_pages (page_path, content_id, page_type, title, thumbnail_url, shop_name, total_count, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+       ON CONFLICT(page_path) DO UPDATE SET
+         title = excluded.title,
+         thumbnail_url = excluded.thumbnail_url,
+         shop_name = excluded.shop_name,
+         updated_at = excluded.updated_at`
+    )
+    .bind(pagePath, contentId, pageType, visit.title, visit.thumbnail?.url ?? '', visit.shop?.name ?? '', now)
+    .run()
+}
 
+/**
+ * クライアントビーコンからのPVカウント加算。
+ * seed済み（popular_pagesに存在する）ページのみ加算し、未知idは no-op。
+ * これにより forged id によるゴミ行挿入・経路汚染を構造的に防ぐ。
+ * pagePath はサーバー側で組み立て、クライアントの文字列は信用しない。
+ */
+export const incrementPageView = async ({ db, contentId }: IncrementPageViewParams) => {
+  const pagePath = `/visits/${contentId}`
+  const seeded = await db
+    .prepare('SELECT 1 FROM popular_pages WHERE page_path = ?')
+    .bind(pagePath)
+    .first()
+  if (!seeded) return false
+
+  const today = new Date().toISOString().split('T')[0]
   await db.batch([
     // daily_pages: 日別カウントをupsert
     db
       .prepare(
         `INSERT INTO daily_pages (page_path, content_id, page_type, date, count)
-         VALUES (?, ?, ?, ?, 1)
+         VALUES (?, ?, 'visit', ?, 1)
          ON CONFLICT(page_path, date) DO UPDATE SET count = count + 1`
       )
-      .bind(pagePath, contentId, pageType, today),
+      .bind(pagePath, contentId, today),
 
-    // popular_pages: 累計カウントをupsert + メタ情報更新
+    // popular_pages: 既存行の累計カウントのみ加算（メタは触らない）
     db
-      .prepare(
-        `INSERT INTO popular_pages (page_path, content_id, page_type, title, thumbnail_url, shop_name, total_count, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, 1, ?)
-         ON CONFLICT(page_path) DO UPDATE SET
-           total_count = total_count + 1,
-           title = excluded.title,
-           thumbnail_url = excluded.thumbnail_url,
-           shop_name = excluded.shop_name,
-           updated_at = excluded.updated_at`
-      )
-      .bind(
-        pagePath,
-        contentId,
-        pageType,
-        visit.title,
-        visit.thumbnail?.url ?? '',
-        visit.shop?.name ?? '',
-        now
-      ),
+      .prepare('UPDATE popular_pages SET total_count = total_count + 1 WHERE page_path = ?')
+      .bind(pagePath),
   ])
+  return true
 }

--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -1,0 +1,4 @@
+import { createRoute } from 'honox/factory'
+import { responseCache } from '../libs/cache'
+
+export default createRoute(responseCache)

--- a/app/routes/api/pageview.ts
+++ b/app/routes/api/pageview.ts
@@ -1,0 +1,23 @@
+import { createRoute } from 'honox/factory'
+import { incrementPageView } from '../../libs/pageview'
+
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/
+
+// PVビーコン受信。クライアントからは visit の id のみ受け取り、
+// seed済みページに限りカウントを加算する（経路・メタは信用しない）。
+export const POST = createRoute(async (c) => {
+  let id = ''
+  try {
+    const body = (await c.req.json()) as { id?: unknown }
+    id = typeof body.id === 'string' ? body.id : ''
+  } catch {
+    return c.body(null, 400)
+  }
+
+  if (!ID_PATTERN.test(id)) {
+    return c.body(null, 400)
+  }
+
+  await incrementPageView({ db: c.env.DB, contentId: id })
+  return c.body(null, 204)
+})

--- a/app/routes/visits/[id].tsx
+++ b/app/routes/visits/[id].tsx
@@ -5,7 +5,7 @@ import {
   getPrevVisits,
   getNextVisits,
 } from '../../libs/microcms'
-import { recordPageView } from '../../libs/pageview'
+import { seedPageViewMeta } from '../../libs/pageview'
 import { getCommentsByVisitId, createComment } from '../../libs/comment'
 import { verifyTurnstile } from '../../libs/turnstile'
 import { notifyNewComment } from '../../libs/notification'
@@ -22,6 +22,7 @@ import { CommentList } from '../../components/CommentList'
 import { getShopGenreString } from '../../utils/getShopGenreString'
 import { CommentForm } from '../../islands/CommentForm'
 import { Alert } from '../../islands/Alert'
+import { PageViewBeacon } from '../../islands/PageViewBeacon'
 import { getCookie, setCookie, deleteCookie } from 'hono/cookie'
 
 const authorCookieKey = 'meshi-log-author'
@@ -91,8 +92,9 @@ export default createRoute(async (c) => {
   ])
   const url = new URL(c.req.url)
   const canonicalUrl = `${url.protocol}//${url.host}/visits/${id}`
-  // 前回の名前を取得
-  const author = getCookie(c, authorCookieKey) || ''
+  // 共有エッジキャッシュで他人に名前が漏れるのを防ぐため、コメント投稿者名の
+  // サーバー差し込みは行わない（HTMLを全ユーザー共通にする）。
+  const author = ''
   const successMessage = getCookie(c, successAlertCookieKey)
   if (successMessage) deleteCookie(c, successAlertCookieKey, { path: '/' })
 
@@ -105,9 +107,9 @@ export default createRoute(async (c) => {
     errorMessage = '名前とコメントを正しく入力してください。'
   }
 
-  // ページビュー記録（レスポンスをブロックしない）
+  // 人気ページ用メタ情報をseed（カウントはクライアントビーコンが加算する）
   c.executionCtx.waitUntil(
-    recordPageView({
+    seedPageViewMeta({
       db: c.env.DB,
       pagePath: `/visits/${id}`,
       contentId: id,
@@ -168,6 +170,8 @@ export default createRoute(async (c) => {
       <AdjacentPosts nextVisits={nextVisits.contents} prevVisits={prevVisits.contents} />
       {/* 戻るリンク */}
       <LinkToTop />
+      {/* PV計測ビーコン（キャッシュ済みページでもブラウザで発火） */}
+      <PageViewBeacon id={id} />
     </Container>,
     { meta }
   )

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,6 @@
       "binding": "DB",
       "database_name": "meshi-log-db",
       "database_id": "0dd6b9b2-c2c3-4b61-a769-9fc99086a112",
-      "remote": true,
     },
   ],
   "kv_namespaces": [


### PR DESCRIPTION
Closes #122

## 概要

microCMS のデータ転送量を**根本的に**削減するため、公開GETページのHTML/XMLを Cloudflare の共有エッジキャッシュ（`caches.default`）にURLキーでキャッシュする。**ヒット時は microCMS を一切呼ばない**。先行実施済みの「fields絞り込み＋画像最適化」と併用で効果最大化。

TTL=10分（`Cache-Control: public, max-age=600`）。

## キャッシュ対象（GETのみ）

`/`, `/shops`, `/shops/*`, `/visits/*`（`/visits/draft` 除く）, `/sitemap`, `/feed.atom`

除外: `/visits/draft`, `/oauth/*`, `/mcp`・`/mcp/admin`, `/api/*`, `/popular`・`/search` 等。

## 共有キャッシュ対応（副作用の分離）

`caches.default` は**ユーザー単位ではなくエッジ共有**のため、`visits/[id]` の以下を作り替えた:

- **PVカウント**: サーバーレンダリング時の記録だとキャッシュヒットで漏れるため、**クライアントビーコン方式**に移行（`PageViewBeacon` → `POST /api/pageview`）。キャッシュと独立してPVを計測。
  - `seedPageViewMeta`（メタ情報のみ・信頼値をサーバーが書く）と `incrementPageView`（seed済みページのみcount加算）に分割。
  - `/api/pageview` は id をバリデーションし、**seed済みページのみ**加算。未知idは no-op で forged 行挿入・経路汚染を構造的に防止。
- **名前漏洩防止**: コメント投稿者名の cookie からのサーバー差し込みを廃止（共有キャッシュで他人に漏れるため）。

## 保存ガード

`status === 200` かつ `Set-Cookie` を持たないレスポンスのみ保存。これにより、コメント投稿直後（成功アラート/cookie操作）のレスポンスはキャッシュされず、投稿本人は新鮮なページを見る。

## その他

- `wrangler.jsonc` の D1 binding から `"remote": true` を削除し、ローカル開発を本番DBから分離。

## 検証

- `yarn build` / `tsc --noEmit` パス。
- ローカル（`wrangler dev`）でヘッダ確認:
  - `/`・`/feed.atom`・`/visits/<id>`・`/shops` → `Cache-Control: public, max-age=600` 付与
  - `/popular`・`/oauth/authorize`・`/visits/draft` → 対象外
  - コメントフォームの名前欄が空（漏洩なし）
  - ビーコン: 正常id→204 / 不正→400 / 未seed id→204 no-op

## スコープ外（将来拡張）

microCMS Webhook によるキャッシュパージ（新規投稿時の即時無効化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)