### PR TITLE
feat: OAuth認可をCloudflare Zero Trust認証に移行

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -17,7 +17,8 @@ declare module 'hono' {
       TURNSTILE_SECRET_KEY: string
       EMAIL: SendEmail
       NOTIFICATION_EMAIL: string
-      ADMIN_PASSWORD: string
+      CF_ACCESS_TEAM_DOMAIN: string
+      CF_ACCESS_AUDIENCE: string
       OAUTH_KV: KVNamespace
       OAUTH_PROVIDER: OAuthHelpers
       MICROCMS_WEBHOOK_SECRET: string

--- a/app/routes/oauth/authorize.tsx
+++ b/app/routes/oauth/authorize.tsx
@@ -1,140 +1,32 @@
 import { createRoute } from 'honox/factory'
-import { css, Style } from 'hono/css'
-
-const bodyClass = css`
-  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-  max-width: 420px;
-  margin: 64px auto;
-  padding: 24px;
-  color: #222;
-`
-
-const headingClass = css`
-  font-size: 1.25rem;
-  margin-bottom: 1rem;
-`
-
-const infoClass = css`
-  background: #f5f5f5;
-  padding: 12px 16px;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  margin-bottom: 16px;
-  dt {
-    font-weight: 600;
-    color: #555;
-  }
-  dd {
-    margin: 0 0 8px 0;
-    word-break: break-all;
-  }
-`
-
-const inputClass = css`
-  width: 100%;
-  padding: 10px;
-  font-size: 1rem;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  box-sizing: border-box;
-`
-
-const buttonClass = css`
-  width: 100%;
-  padding: 12px;
-  margin-top: 12px;
-  font-size: 1rem;
-  background: #111;
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  &:hover {
-    background: #333;
-  }
-`
-
-const errorClass = css`
-  color: #c33;
-  margin-bottom: 12px;
-  font-size: 0.9rem;
-`
-
-const Page = ({
-  clientName,
-  scope,
-  error,
-}: {
-  clientName: string
-  scope: string
-  error?: string
-}) => (
-  <html lang="ja">
-    <head>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <meta name="robots" content="noindex,nofollow" />
-      <title>meshi-log MCP Authorize</title>
-      <Style />
-    </head>
-    <body class={bodyClass}>
-      <h1 class={headingClass}>MCP Authorization</h1>
-      <dl class={infoClass}>
-        <dt>Client</dt>
-        <dd>{clientName}</dd>
-        <dt>Scope</dt>
-        <dd>{scope || '(none)'}</dd>
-      </dl>
-      {error && <p class={errorClass}>{error}</p>}
-      <form method="post">
-        <input
-          type="password"
-          name="password"
-          placeholder="Admin password"
-          autofocus
-          required
-          class={inputClass}
-        />
-        <button type="submit" class={buttonClass}>
-          Authorize
-        </button>
-      </form>
-    </body>
-  </html>
-)
+import { verifyWithJwks } from 'hono/jwt'
 
 export const GET = createRoute(async (c) => {
-  const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
-  const client = await c.env.OAUTH_PROVIDER.lookupClient(oauthReqInfo.clientId)
-  const clientName = client?.clientName ?? oauthReqInfo.clientId
-  const scope = oauthReqInfo.scope.join(' ')
-  return c.html(<Page clientName={clientName} scope={scope} />)
-})
+  const token = c.req.header('Cf-Access-Jwt-Assertion')
+  if (!token) return c.text('Unauthorized', 401)
 
-export const POST = createRoute(async (c) => {
-  const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
-  const formData = await c.req.formData()
-  const password = formData.get('password')
-
-  if (typeof password !== 'string' || password !== c.env.ADMIN_PASSWORD) {
-    const client = await c.env.OAUTH_PROVIDER.lookupClient(oauthReqInfo.clientId)
-    const clientName = client?.clientName ?? oauthReqInfo.clientId
-    return c.html(
-      <Page
-        clientName={clientName}
-        scope={oauthReqInfo.scope.join(' ')}
-        error="パスワードが正しくありません"
-      />,
-      401
+  let email: string
+  try {
+    const payload = await verifyWithJwks(
+      token,
+      {
+        jwks_uri: `https://${c.env.CF_ACCESS_TEAM_DOMAIN}/cdn-cgi/access/certs`,
+        allowedAlgorithms: ['RS256'],
+      },
+      { cf: { cacheEverything: true, cacheTtl: 3600 } }
     )
+    email = payload.email as string
+  } catch {
+    return c.text('Unauthorized', 401)
   }
 
+  const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw)
   const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
     request: oauthReqInfo,
-    userId: 'admin',
+    userId: email,
     scope: oauthReqInfo.scope,
-    metadata: {},
-    props: {},
+    metadata: { email },
+    props: { email },
   })
   return c.redirect(redirectTo)
 })

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,4 +25,8 @@
       "id": "7ec3029befa84fabb270604c30c9c346",
     },
   ],
+  "vars": {
+    "CF_ACCESS_TEAM_DOMAIN": "divine-hat-a280.cloudflareaccess.com",
+    "CF_ACCESS_AUDIENCE": "1ed3fbcd60be1ac4246dbd0a0e2ebe2ea54e85dd612cd50f295754d54af22931",
+  },
 }


### PR DESCRIPTION
## Summary

- `/oauth/authorize` のパスワード認証を Cloudflare Zero Trust + Cloudflare アカウント認証に置き換え
- `hono/jwt` の `verifyWithJwks` で `Cf-Access-Jwt-Assertion` ヘッダーの JWT を検証（外部パッケージ追加なし）
- `ADMIN_PASSWORD` シークレット不要になるため削除可（`npx wrangler secret delete ADMIN_PASSWORD`）

## Changes

- `app/routes/oauth/authorize.tsx`: パスワードフォームを削除、JWT検証のみのシンプルな実装に
- `app/global.d.ts`: `ADMIN_PASSWORD` → `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUDIENCE`
- `wrangler.jsonc`: `CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUDIENCE` を vars に追加

## Zero Trust 設定（事前完了済み）

- Access Application: `meshi-log.info` / `/oauth/authorize`
- Identity Provider: Cloudflare
- Policy: Allow / Emails / `kuri0403@gmail.com`

## Test plan

- [ ] `yarn deploy` でデプロイ済み・動作確認済み
- [ ] Claude Desktop の `/mcp/admin` コネクタを削除→再追加で認可フローが走ることを確認
- [ ] 許可されていないアカウントでは 401 になることを確認
- [ ] `npx wrangler secret delete ADMIN_PASSWORD` で旧シークレットを削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)